### PR TITLE
デプロイの変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: production deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+
+      - name: generate
+        run: npm run generate --fail-on-page-error
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: production

--- a/pm2.config.yaml
+++ b/pm2.config.yaml
@@ -1,9 +1,0 @@
-apps:
-  - script: npm
-    args:
-      - run
-      - start
-    name: '3000:ap-mayfes-2020'
-    exec_mode: cluster
-    autorestart: true
-    watch: false


### PR DESCRIPTION
workflowを利用し、サーバービルドしないように変更。これにより、デプロイ作業が `git pull` のみで終了し、ゼロダウンタイムとなる